### PR TITLE
Convert functionality to a class and add exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # chillwave.js
 
 A l l&nbsp;&nbsp;&nbsp;y o u&nbsp;&nbsp;&nbsp;h a v e&nbsp;&nbsp;&nbsp;t o&nbsp;&nbsp;&nbsp;d o&nbsp;&nbsp;&nbsp;i s&nbsp;&nbsp;&nbsp;p a s s&nbsp;&nbsp;&nbsp;y o u r&nbsp;&nbsp;&nbsp;s t r i n g&nbsp;&nbsp;&nbsp;t o&nbsp;&nbsp;&nbsp;t h e&nbsp;&nbsp;&nbsp;m a k e C h i l l W a v e S t r i n g ( )&nbsp;&nbsp;&nbsp;f u n c t i o n&nbsp;&nbsp;&nbsp;a n d&nbsp;&nbsp;&nbsp;l e t&nbsp;&nbsp;&nbsp;t h e&nbsp;&nbsp;&nbsp;m a g i c&nbsp;&nbsp;&nbsp;h a p p e n !
+
+## Example
+```js
+const c = new ChillWaveString('AESTHETIC');
+console.log(c.render());
+```

--- a/chillwave.js
+++ b/chillwave.js
@@ -1,12 +1,14 @@
-const convert = str => str.split('').join(' ');
-/**
- * 
- * @param {String} str | The string to be converted
- * @param {Boolean} shouldTrim | Trim whitespace on either side of given string
- * 
- */
-const chillWave = (str, shouldTrim = true) => {
-    return shouldTrim
-        ? convert(str.trim())
-        : convert(str);
+class ChillWaveString {
+  /**
+   * @param {String} str
+   */
+  constructor(str) {
+    this.str = str;
+  }
+
+  render() {
+    return this.str.split('').join(' ');
+  }
 };
+
+module.exports = ChillWaveString;


### PR DESCRIPTION
Turned this into a class so that its functionality is encapsulated.
Also removed unnecessary “shouldTrim” param since we can simply call
.trim() after .render() now if we want it.

`const cws = new ChillWaveString('   Needs some trimming        ');
console.log(cws.render().trim());`